### PR TITLE
Prevent "repodata over 2 weeks old" prompt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM virusvn/docker-centos-v8js:nginx-php-fpm
 
+RUN yum clean all
 RUN yum install -y php-mysqli vim
 
 RUN cd /tmp \


### PR DESCRIPTION
During the build step it can sometimes hang due to a prompt to install `yum cron`, running `yum clean all` before hand prevents this.